### PR TITLE
Allow setting only one motor at a time

### DIFF
--- a/pi/a_star.py
+++ b/pi/a_star.py
@@ -37,11 +37,11 @@ class AStar:
     self.write_pack(24, 'B15s', 1, notes.encode("ascii"))
 
   def motors(self, left, right):
-    if left:
+    if left is not None:
       self._old_left_motor_val = left
     else:
       left = self._old_left_motor_val
-    if right:
+    if right is not None:
       self._old_right_motor_val = right
     else:
       right = self._old_right_motor_val

--- a/pi/a_star.py
+++ b/pi/a_star.py
@@ -6,6 +6,8 @@ import time
 class AStar:
   def __init__(self):
     self.bus = smbus.SMBus(1)
+    self._old_left_motor_val = None
+    self._old_right_motor_val = None
 
   def read_unpack(self, address, size, format):
     # Ideally we could do this:
@@ -35,6 +37,14 @@ class AStar:
     self.write_pack(24, 'B15s', 1, notes.encode("ascii"))
 
   def motors(self, left, right):
+    if left:
+      self._old_left_motor_val = left
+    else:
+      left = self._old_left_motor_val
+    if right:
+      self._old_right_motor_val = right
+    else:
+      right = self._old_right_motor_val
     self.write_pack(6, 'hh', left, right)
 
   def read_buttons(self):

--- a/pi/a_star.py
+++ b/pi/a_star.py
@@ -6,8 +6,8 @@ import time
 class AStar:
   def __init__(self):
     self.bus = smbus.SMBus(1)
-    self._old_left_motor_val = None
-    self._old_right_motor_val = None
+    self._old_left_motor_val = 0
+    self._old_right_motor_val = 0
 
   def read_unpack(self, address, size, format):
     # Ideally we could do this:


### PR DESCRIPTION
Cache the previous motor value so that if a None value is sent for one of the motors, it is re-set to the previous stored value. This allows higher level code using this module to set one motor without knowing the state of the other.