### PR TITLE
fixed missing return

### DIFF
--- a/src/PololuTWISlave.cpp
+++ b/src/PololuTWISlave.cpp
@@ -87,4 +87,6 @@ uint8_t PololuTWISlave::handleEvent(uint8_t event)
       PololuTWISlave::clearBusError();
       break;
   }
+    
+  return 0; //what should we be returning?
 }


### PR DESCRIPTION
uint8_t PololuTWISlave::handleEvent(uint8_t event) is declared with a return type yet didn't return anything, which could cause trouble if someone tried to read the return value. I added a trivial return 0; I'm sure there is more useful info top return, but this is at least safe.